### PR TITLE
CSS fixes for embed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,33 +27,7 @@ class App extends React.Component {
       row: parseInt(row)
     });
 
-    var modal = document.getElementById("info-modal");
-    var span = document.getElementsByClassName("sc-modal-close")[0];
-    modal.style.display = "block";
-    modal.scrollTop = 0;
-
-
-    span.onclick = (event) => {
-      modal.style.display = "none";
-      this.setState({
-        candidate: null,
-        row: 0,
-        table: 0,
-        lastClicked: lastClicked
-      });
-    }
-
-    window.onclick = (event) => {
-      if (event.target === modal) {
-        modal.style.display = "none";
-        this.setState({
-          candidate: null,
-          row: 0,
-          table: 0,
-          lastClicked: lastClicked
-        });
-      }
-    }
+    this.openModal(lastClicked);
   }
 
   onClickIcon = (row, table) => {
@@ -64,32 +38,7 @@ class App extends React.Component {
       row: parseInt(row)
     });
 
-    var modal = document.getElementById("info-modal");
-    var span = document.getElementsByClassName("sc-modal-close")[0];
-    modal.style.display = "block";
-    modal.scrollTop = 0;
-
-    span.onclick = (event) => {
-      modal.style.display = "none";
-      this.setState({
-        candidate: null,
-        row: 0,
-        table: 0,
-        lastClicked: lastClicked
-      });
-    }
-
-    window.onclick = (event) => {
-      if (event.target === modal) {
-        modal.style.display = "none";
-        this.setState({
-          candidate: null,
-          row: 0,
-          table: 0,
-          lastClicked: lastClicked
-        });
-      }
-    }
+    this.openModal(lastClicked);
   }
 
   onClickNav = (id) => {
@@ -105,6 +54,35 @@ class App extends React.Component {
       candidate: newCandidate
     })
     }
+
+  openModal(lastClicked) {
+    var modal = document.getElementById("info-modal");
+    var span = document.getElementsByClassName("sc-modal-close")[0];
+    modal.style.display = "block";
+    modal.scrollTop = 0;
+
+    span.onclick = (event) => {
+      modal.style.display = "none";
+      this.setState({
+        candidate: null,
+        row: 0,
+        table: 0,
+        lastClicked: lastClicked
+      });
+    };
+    
+    window.onclick = (event) => {
+      if (event.target === modal) {
+        modal.style.display = "none";
+        this.setState({
+          candidate: null,
+          row: 0,
+          table: 0,
+          lastClicked: lastClicked
+        });
+      }
+    };
+  }
 
   render () {
     return (

--- a/src/App.js
+++ b/src/App.js
@@ -30,6 +30,8 @@ class App extends React.Component {
     var modal = document.getElementById("info-modal");
     var span = document.getElementsByClassName("sc-modal-close")[0];
     modal.style.display = "block";
+    modal.scrollTop = 0;
+
 
     span.onclick = (event) => {
       modal.style.display = "none";
@@ -65,6 +67,7 @@ class App extends React.Component {
     var modal = document.getElementById("info-modal");
     var span = document.getElementsByClassName("sc-modal-close")[0];
     modal.style.display = "block";
+    modal.scrollTop = 0;
 
     span.onclick = (event) => {
       modal.style.display = "none";

--- a/src/candidateInfo.css
+++ b/src/candidateInfo.css
@@ -148,7 +148,7 @@
     }
 
     .sc-modal-close {
-        position: absolute;
+        position: fixed;
         top: 0;
         right: .3em;
         background: none;

--- a/src/common/header.css
+++ b/src/common/header.css
@@ -1,5 +1,5 @@
 .header-container {
-    position: fixed;
+    position: sticky;
     top: 0;
     background: white;
     min-width: 100%;

--- a/src/common/header.css
+++ b/src/common/header.css
@@ -7,6 +7,10 @@
 
 }
 
+#sunrise-img {
+    min-width: 62px;
+}
+
 .caption {
     font-size: 18px;
     color: #33342E;
@@ -21,7 +25,7 @@
     flex-direction: row;
 	align-items: center;
 	justify-content: space-between;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
 }
 
 .header-title {

--- a/src/common/header.js
+++ b/src/common/header.js
@@ -14,7 +14,7 @@ function Header(props) {
                 <div className="caption">Click on a candidate's score for more details on their plan.</div>
             </div>
             <div className="sunrise-logo">
-             <img src={sunrise} alt="Sunrise logo"></img>
+             <img id="sunrise-img" src={sunrise} alt="Sunrise logo"></img>
             </div>
          </header>
          <Nav onClickNav={props.onClickNav} />

--- a/src/common/nav.css
+++ b/src/common/nav.css
@@ -22,6 +22,22 @@
     border-bottom: 4px solid #FFDE16;
 }
 
+@media screen and (max-width: 940px) {
+
+    .nav-item {
+        font-size: 16px;
+        /* line-height: 22px; */
+    }
+    
+  }
+
+  @media screen and (max-width: 850px) {
+    .nav-item {
+        font-size: 14.7px;
+        /* line-height: 19px; */
+    }
+  }
+
 @media screen and (max-width: 790px) {
 
     .navbar {

--- a/src/modal.css
+++ b/src/modal.css
@@ -16,7 +16,8 @@
     background-color: #fefefe;
     margin: auto;
     width: 78%;
-    min-height: 65%;
+    max-width: 1250px;
+    min-height: 25%;
   }
 
   .sc-modal-content {

--- a/src/modal.css
+++ b/src/modal.css
@@ -1,7 +1,7 @@
 .sc-modal {
     display: none;
     position: fixed; /* Stay in place */
-    z-index: 1; /* Sit on top */
+    z-index: 4000; /* Sit on top */
     padding-top: 11vh; /* Location of the box */
     left: 0;
     top: 0;

--- a/src/table.css
+++ b/src/table.css
@@ -51,6 +51,7 @@
 
 .expand-icon {
   display: none;
+  max-width: 18px;
 }
 
 #icon-cell {

--- a/src/table.css
+++ b/src/table.css
@@ -18,7 +18,7 @@
 
 .row-title {
   padding-left: 10px;
-  font-weight: 400 !important;
+  font-weight: 400;
 }
 
 .sc-table th {

--- a/src/table.css
+++ b/src/table.css
@@ -46,6 +46,7 @@
 
 .sc-table td.row-title:hover{
   background: #F4F4F4;
+  cursor: auto; /* Remove this once row on-click is working properly */
 }
 
 .expand-icon {

--- a/src/table.css
+++ b/src/table.css
@@ -46,7 +46,6 @@
 
 .sc-table td.row-title:hover{
   background: #F4F4F4;
-  cursor: auto;
 }
 
 .expand-icon {

--- a/src/table.css
+++ b/src/table.css
@@ -51,6 +51,9 @@
 
 .expand-icon {
   display: none;
+}
+
+#expand-icon {
   max-width: 18px;
 }
 

--- a/src/table.css
+++ b/src/table.css
@@ -18,6 +18,7 @@
 
 .row-title {
   padding-left: 10px;
+  font-weight: 400 !important;
 }
 
 .sc-table th {
@@ -74,6 +75,7 @@
 
 .table-title {
   display: inline-block;
+  margin-block-start: 0.83em !important;
   margin-block-end: 0;
   font-style: normal;
   font-weight: bold;
@@ -90,6 +92,8 @@
   letter-spacing: 0.11em;
   text-transform: uppercase;
   color: #33342E;
+  margin-block-start: 1.33em !important;
+  margin-block-end: 1.33em !important;
 }
 
 .table-description{

--- a/src/table.js
+++ b/src/table.js
@@ -26,12 +26,12 @@ function Table(props) {
         props.onClickIcon(e.target.parentElement.parentElement.id, props.id);
     }
 
-    const handleRowClick = (e) => {
-        e.preventDefault();
-        console.log(e.target.parentElement.id)
-        // pass in row index and table index
-        props.onClickIcon(e.target.parentElement.id, props.id);
-    }
+    // const handleRowClick = (e) => {
+    //     e.preventDefault();
+
+    //     // pass in row index and table index
+    //     props.onClickIcon(e.target.parentElement.id, props.id);
+    // }
 
     // If there's a category title, it is the GND Vision section
     const isGNDVisionTable = (props.table.categorytitle) ? true : false;

--- a/src/table.js
+++ b/src/table.js
@@ -54,7 +54,7 @@ function Table(props) {
         <div id={props.table.id} name={props.table.id}>
 
         { isGNDVisionTable
-            ? <div><h2 id='title' className="table-title">{props.table.categorytitle}</h2>
+            ? <div><div id='title' className="table-title">{props.table.categorytitle}</div>
                     <span className="table-points"> (out of {props.table.categorypoints})</span></div>
             : <span></span>
           }
@@ -67,7 +67,7 @@ function Table(props) {
             </div>
             : 
             <div>
-                <h2 id='title' className="table-title">{props.table.title}</h2>
+                <div id='title' className="table-title">{props.table.title}</div>
                 <span className="table-points"> (out of {props.table.points})</span>
                 <div className="table-description">{props.table.description}</div>
             </div>

--- a/src/table.js
+++ b/src/table.js
@@ -28,7 +28,7 @@ function Table(props) {
 
     const handleRowClick = (e) => {
         e.preventDefault();
-                
+        console.log(e.target.parentElement.id)
         // pass in row index and table index
         props.onClickIcon(e.target.parentElement.id, props.id);
     }
@@ -47,7 +47,7 @@ function Table(props) {
         const {title, total, biden, warren, sanders } = row;
         return (
             <tr id={index} key={index}>
-                <td onClick={handleRowClick}  className="row-title"><img onClick={handleIconClick} className="info-icon" alt="Information Icon" src={icon}></img>{title} <span className="row-points">(Out of {total})</span></td>
+                <td className="row-title"><img onClick={handleIconClick} className="info-icon" alt="Information Icon" src={icon}></img>{title} <span className="row-points">(Out of {total})</span></td>
                 <td onClick={handleClick} id="biden">{biden.score}</td>
                 <td onClick={handleClick} id="warren">{warren.score}</td>
                 <td onClick={handleClick} id="sanders">{sanders.score}</td>

--- a/src/table.js
+++ b/src/table.js
@@ -44,7 +44,7 @@ function Table(props) {
                 <td onClick={handleClick} id="biden">{biden.score}</td>
                 <td onClick={handleClick} id="warren">{warren.score}</td>
                 <td onClick={handleClick} id="sanders">{sanders.score}</td>
-                <td id="icon-cell"> &nbsp;<img className="expand-icon" onClick={handleRowClick} alt="Information Icon" src={expand}></img></td>
+                <td id="icon-cell"> &nbsp;<img id="expand-icon" className="expand-icon" onClick={handleRowClick} alt="Information Icon" src={expand}></img></td>
             </tr>
         )
     });

--- a/src/table.js
+++ b/src/table.js
@@ -19,11 +19,18 @@ function Table(props) {
         props.onClickIcon(e.target.parentElement.parentElement.id, props.id);
     }
 
-    const handleRowClick = (e) => {
+    const handleChevronClick = (e) => {
         e.preventDefault();
                 
         // pass in row index and table index
         props.onClickIcon(e.target.parentElement.parentElement.id, props.id);
+    }
+
+    const handleRowClick = (e) => {
+        e.preventDefault();
+                
+        // pass in row index and table index
+        props.onClickIcon(e.target.parentElement.id, props.id);
     }
 
     // If there's a category title, it is the GND Vision section
@@ -40,11 +47,11 @@ function Table(props) {
         const {title, total, biden, warren, sanders } = row;
         return (
             <tr id={index} key={index}>
-                <td className="row-title"><img onClick={handleIconClick} className="info-icon" alt="Information Icon" src={icon}></img>{title} <span className="row-points">(Out of {total})</span></td>
+                <td onClick={handleRowClick}  className="row-title"><img onClick={handleIconClick} className="info-icon" alt="Information Icon" src={icon}></img>{title} <span className="row-points">(Out of {total})</span></td>
                 <td onClick={handleClick} id="biden">{biden.score}</td>
                 <td onClick={handleClick} id="warren">{warren.score}</td>
                 <td onClick={handleClick} id="sanders">{sanders.score}</td>
-                <td id="icon-cell"> &nbsp;<img id="expand-icon" className="expand-icon" onClick={handleRowClick} alt="Information Icon" src={expand}></img></td>
+                <td id="icon-cell"> &nbsp;<img id="expand-icon" className="expand-icon" onClick={handleChevronClick} alt="Information Icon" src={expand}></img></td>
             </tr>
         )
     });

--- a/src/tables.css
+++ b/src/tables.css
@@ -1,7 +1,5 @@
 .tables-container {
-    margin: 0 30px;
-    /* padding-top: 0; */
-    padding-bottom: 5em;
+    padding: 0 30px 5em 30px;
     background-color: white;
   }
 
@@ -14,8 +12,7 @@
 
   @media screen and (max-width: 520px) {
     .tables-container {
-      margin: 0 15px;
-      padding-bottom: 3em;
+      padding: 0 15px 3em 15px;
     }
   }
 

--- a/src/tables.css
+++ b/src/tables.css
@@ -1,7 +1,8 @@
 .tables-container {
     margin: 0 30px;
-    padding-top: 17.5em;
+    padding-top: 1em;
     padding-bottom: 5em;
+    background-color: white;
   }
 
   @media screen and (max-width: 790px) {

--- a/src/tables.css
+++ b/src/tables.css
@@ -1,6 +1,6 @@
 .tables-container {
     margin: 0 30px;
-    padding-top: 1em;
+    /* padding-top: 0; */
     padding-bottom: 5em;
     background-color: white;
   }

--- a/src/totalsTable.js
+++ b/src/totalsTable.js
@@ -6,7 +6,7 @@ function TotalsTable(props) {
 
     return (
         <div className="totals-table" id="table-9">
-            <h2 id='title' className="table-title">Totals</h2> <span className="table-points">(out of 200)</span>
+            <div id='title' className="table-title">Totals</div> <span className="table-points">(out of 200)</span>
             <table className="sc-table">
                 <tbody>
                 <tr id="header">


### PR DESCRIPTION
These CSS updates make some selectors more specific so we can override squarespace's default styling. The header panel is now sticky instead of fixed so should stay at top of screen once the user scrolls down.

Edit: also fixed some weird modal sizing stuff, made sure the modal close button is always visible on mobile, and reset modal scroll position every time it's opened.