### PR TITLE
Add source section to modal if the data exists

### DIFF
--- a/src/candidateAnalysis.js
+++ b/src/candidateAnalysis.js
@@ -13,6 +13,15 @@ function CandidateAnalysis(props) {
                 <div className="analysis-text">
                     {props.candidateObject.analysis}
             </div>
+
+            {props.candidateObject.source &&
+            (<div>
+                <div id="analyses-title">Source</div>
+                    <div className="analysis-text">
+                        {props.candidateObject.source}
+                    </div>
+                </div>)    
+            }
         </div>
     );
 }

--- a/src/candidateInfo.css
+++ b/src/candidateInfo.css
@@ -86,7 +86,7 @@
     font-size: 18px;
     line-height: 27px;
     color: #33342E;
-    overflow-y: scroll;
+    overflow-y: auto;
     background-color: white;
 }
 

--- a/src/data.js
+++ b/src/data.js
@@ -20,7 +20,8 @@ const scorecardData = {
                "total":"4",
                "biden":{ 
                   "score":"3",
-                  "analysis":"Candidate score analysis will go here"
+                  "analysis":"Candidate score analysis will go here",
+                  "source": "sources will go here"
                },
                "warren":{ 
                   "score":"4",

--- a/src/modal.css
+++ b/src/modal.css
@@ -36,7 +36,7 @@
     min-height: 37em;
     max-height: 37em;
     padding: 1.5em;
-    overflow: scroll;
+    overflow: auto;
   }
 
 .modal-table-title {
@@ -82,7 +82,7 @@
   .modal-description{
     min-height: 200px;
     min-width: 100%;
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 }
 
@@ -94,7 +94,7 @@
   .modal-description{
     min-height: 30vh;
     min-width: 100vw;
-    overflow: scroll;
+    overflow: auto;
     padding: 25px;
     padding-top: 0px;
   }

--- a/src/table.css
+++ b/src/table.css
@@ -138,7 +138,7 @@
 /* Spacing specific to desktop */
 @media screen and (min-width: 520px) {
   .sc-table {
-    margin-top: 10px;
+    margin-top: 0px;
   }
 
   .table-title {


### PR DESCRIPTION
Adds a property adjacent to the 'analysis' property in a candidate's row data with the key 'source'. If that value exists, the app will render it below the analyses (see screenshot).

<img width="1136" alt="Screen Shot 2019-12-04 at 5 44 04 PM" src="https://user-images.githubusercontent.com/25851057/70188050-b20c4500-16bd-11ea-866c-20af130f020f.png">

This PR also has a tiny CSS update for issue T15.
