### PR TITLE
Link styling and modal scroll issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,10 @@ class App extends React.Component {
     }
 
   onClickModalNav = (e) => {
-    let newCandidate = e.target.dataset.name
+    let newCandidate = e.target.dataset.name;
+
+    var myDiv = document.getElementsByClassName('analysis-container')[0]
+    myDiv.scrollTop = 0;
 
     this.setState({
       candidate: newCandidate

--- a/src/App.js
+++ b/src/App.js
@@ -71,8 +71,8 @@ class App extends React.Component {
   onClickModalNav = (e) => {
     let newCandidate = e.target.dataset.name;
 
-    var myDiv = document.getElementsByClassName('analysis-container')[0]
-    myDiv.scrollTop = 0;
+    var analysisContainer = document.getElementsByClassName('analysis-container')[0]
+    analysisContainer.scrollTop = 0;
 
     this.setState({
       candidate: newCandidate

--- a/src/App.js
+++ b/src/App.js
@@ -51,7 +51,7 @@ class App extends React.Component {
     this.openModal(lastClicked);
   }
 
-  onClickIcon = (row, table) => {
+  onClickRow = (row, table) => {
     let lastClicked = {candidate: null, row: row };
 
     this.setState({
@@ -130,7 +130,7 @@ class App extends React.Component {
             <ScorecardApp onClickCell={this.onClickCell} 
                           onClickNav={this.onClickNav}
                           scorecardData={data}
-                          onClickIcon={this.onClickIcon}
+                          onClickRow={this.onClickRow}
                           />
             <InfoModal scorecardData={data}
                       candidate={this.state.candidate}

--- a/src/ScorecardApp.js
+++ b/src/ScorecardApp.js
@@ -10,7 +10,7 @@ const ScorecardApp = (props) => (
             <Nav onClickNav={props.onClickNav} />
             <Tables onClickCell={props.onClickCell} 
                     scorecardData={props.scorecardData}
-                    onClickIcon={props.onClickIcon}
+                    onClickRow={props.onClickRow}
                     />
         </div>
     );

--- a/src/candidateInfo.css
+++ b/src/candidateInfo.css
@@ -95,6 +95,14 @@
     padding-bottom: 2em;
 }
 
+.analysis-text  a,
+.analysis-text  a:link, 
+.analysis-text  a:visited, 
+.analysis-text  a:focus, 
+.analysis-text  a:active {
+  color: #33342E;
+}
+
 #analysis-title {
     font-weight: bold;
     padding-bottom: .5em;

--- a/src/candidateInfo.css
+++ b/src/candidateInfo.css
@@ -50,6 +50,7 @@
     padding: .75em;
     line-height: 27px;
     background-color: #F4F4F4;
+    border-right: 2px solid #E0E0E0;
     font-weight: bold;
     font-size: 18px;
     line-height: 24px;
@@ -162,6 +163,10 @@
     .modal-nav-item:hover{
         background: white;
     }
+
+    .modal-nav-item:nth-child(3) {
+        border-right: 0;
+      }
 
     .sc-modal-close {
         display: none;

--- a/src/common/header.js
+++ b/src/common/header.js
@@ -16,7 +16,7 @@ function Header(props) {
             </div>
          </header>
          <div className="caption">
-            Click on a candidate’s score for more details on their plan. This page will be updated with other Democratic candidates’ scores in the coming months. We urge every candidate to fully adopt the policies and messaging framework set out in this scorecard. Please speak out and let every candidate know you want them to adopt all of these policies and messages.
+         Click on a candidate’s score for more details on their plan. This page will be updated with other Democratic candidates’ scores in the coming months. Please speak out and let every candidate know you want them to adopt all of these policies. It is vital for every candidate to fully adopt the policies and messaging framework set out in this scorecard.
         </div>
         </div>
     );

--- a/src/modal.css
+++ b/src/modal.css
@@ -39,6 +39,14 @@
     overflow: auto;
   }
 
+  .modal-description  a,
+  .modal-description  a:link, 
+  .modal-description  a:visited, 
+  .modal-description  a:focus, 
+  .modal-description  a:active {
+    color: #fff;
+  }
+
 .modal-table-title {
     font-weight: bold;
     font-size: 18px;

--- a/src/modalDescription.js
+++ b/src/modalDescription.js
@@ -21,7 +21,7 @@ function ModalDescription(props) {
                     : props.row.title 
                 }
             </span>
-            <span className="modal-row-description" id="row-description-container">
+            <span className="modal-row-description">
               <ReactMarkdown
                 source={isHowMuchTable ? howMuchDescription : props.row.description }
                 escapeHtml={false}

--- a/src/modalDescription.js
+++ b/src/modalDescription.js
@@ -21,7 +21,7 @@ function ModalDescription(props) {
                     : props.row.title 
                 }
             </span>
-            <span className="modal-row-description">
+            <span className="modal-row-description" id="row-description-container">
               <ReactMarkdown
                 source={isHowMuchTable ? howMuchDescription : props.row.description }
                 escapeHtml={false}

--- a/src/table.css
+++ b/src/table.css
@@ -11,7 +11,6 @@
   margin-top: 25px;
 }
 
-
 .subtotal-title {
   font-weight: bold;
 }
@@ -56,10 +55,9 @@
   cursor: pointer;
 }
 
-.sc-table td.row-title:hover{
+/* .sc-table td.row-title:hover{
   background: #F4F4F4;
-  cursor: auto; /* Remove this once row on-click is working properly */
-}
+} */
 
 .expand-icon {
   display: none;

--- a/src/table.js
+++ b/src/table.js
@@ -7,23 +7,25 @@ function Table(props) {
 
     const handleClick = (e) => {
         e.preventDefault();
+        e.stopPropagation();
         
         // pass in row index, table index, and candidate to update state
-        props.onClickCell(e.target.parentElement.id, props.id, e.target.id,);
+        props.onClickCell(e.currentTarget.parentElement.id, props.id, e.target.id,);
     }
 
-    const handleIconClick = (e) => {
+    const handleRowClick = (e) => {
         e.preventDefault();
         
         // pass in row index and table index
-        props.onClickIcon(e.target.parentElement.parentElement.id, props.id);
+        props.onClickRow(e.currentTarget.id, props.id);
     }
 
     const handleChevronClick = (e) => {
         e.preventDefault();
+        e.stopPropagation();
                 
         // pass in row index and table index
-        props.onClickIcon(e.target.parentElement.parentElement.id, props.id);
+        props.onClickRow(e.target.parentElement.parentElement.id, props.id);
     }
 
     // const handleRowClick = (e) => {
@@ -43,8 +45,8 @@ function Table(props) {
     return props.table.rows.map((row, index) => {
         const {title, total, biden, warren, sanders } = row;
         return (
-            <tr id={index} key={index}>
-                <td className="row-title"><img onClick={handleIconClick} className="info-icon" alt="Information Icon" src={icon}></img>{title} <span className="row-points">(out of {total})</span></td>
+            <tr id={index} key={index} onClick={handleRowClick}>
+                <td className="row-title"><img className="info-icon" alt="Information Icon" src={icon}></img>{title} <span className="row-points">(out of {total})</span></td>
                 <td onClick={handleClick} id="biden">{biden.score}</td>
                 <td onClick={handleClick} id="warren">{warren.score}</td>
                 <td onClick={handleClick} id="sanders">{sanders.score}</td>

--- a/src/tables.js
+++ b/src/tables.js
@@ -19,7 +19,7 @@ return (
             key = {i}
             id = {i}
             onClickCell={props.onClickCell}
-            onClickIcon={props.onClickIcon}
+            onClickRow={props.onClickRow}
             />
         })
       }
@@ -32,7 +32,7 @@ return (
               key = {i + 3}
               id = {i + 3}
               onClickCell={props.onClickCell}
-              onClickIcon={props.onClickIcon}
+              onClickRow={props.onClickRow}
               />
           })
         }


### PR DESCRIPTION
This fixes the link color, resets modal scroll position when it re-renders, and adds modal nav dividers per the design spec.

- T18: divider line between candidate tabs
- T63: reset scroll position
- T53: Link styling across app
- T40: one more update to header caption.
- T12: clickable rows